### PR TITLE
Added warning (4596) to the disabled warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
                 ],
                 "msvs_settings": {
                     "VCCLCompilerTool": {
-                        "DisableSpecificWarnings": [ "4506", "4538", "4793" ]
+                        "DisableSpecificWarnings": [ "4506", "4538", "4793", "4596" ]
                     },
                     "VCLinkerTool": {
                         "AdditionalOptions": [ "/ignore:4248" ]


### PR DESCRIPTION
Added warning (4596) to the disabled warnings so that nsfw can be installed (npm i nsfw) on node 22.